### PR TITLE
Bugfix for List::Util::PP

### DIFF
--- a/t/uniqnum.t
+++ b/t/uniqnum.t
@@ -5,6 +5,9 @@ use Test::More;
 use Config ();
 use List::Util::PP qw(max);
 
+my $nuisance = '';
+$nuisance = 1 if $Config::Config{ivsize} == $Config::Config{nvsize};
+
 use constant MAXUINT => ~0;
 use constant MAXINT => ~0 >> 1;
 use constant MININT => -(~0 >> 1) - 1;
@@ -60,8 +63,10 @@ sub iterate_uniqnum {
         }
       }
       elsif ($uj == $ij && $uJ == $iJ && $uF == $iF) {
-        $dupe = 1;
-        last;
+        unless( $nuisance && "$uniq" eq '18446744073709551615' && "$in" =~ /\./ ) { 
+          $dupe = 1;
+          last;
+        }
       }
     }
     push @uniq, $in;


### PR DESCRIPTION
This is really just a demonstration of an idea for fixing the bug in List::Util::PP::uniqnum() that regards ~0 and 2**64 as duplicate values on perls where ivsize and nvsize are both 8.
I'm not even sure that there's any will to fix this bug - but I was interested in finding a pure perl solution that didn't impact too heavily on performance, and I couldn't come up with anything better than specifically testing for this one special case.

The t/uniqnum.t test script also then needed patching as it was treating the buggy behaviour as correct.

Thoughts welcome - but no urgency (IMO).