### PR TITLE
mesh/zip: correctly handle single-element array inputs

### DIFF
--- a/lib/List/Util/PP.pm
+++ b/lib/List/Util/PP.pm
@@ -456,33 +456,37 @@ sub tail ($@) {
 }
 
 sub zip_longest {
+  my $max = max(map $#$_, @_);
   map {
     my $idx = $_;
     [ map $_->[$idx], @_ ];
-  } ( 0 .. max(map $#$_, @_) || -1 )
+  } ( 0 .. ( defined $max && $max >= 0 ? $max : -1 ) )
 }
 
 sub zip_shortest {
+  my $min = min(map $#$_, @_);
   map {
     my $idx = $_;
     [ map $_->[$idx], @_ ];
-  } ( 0 .. min(map $#$_, @_) || -1 )
+  } ( 0 .. ( defined $min && $min >= 0 ? $min : -1 ) )
 }
 
 *zip = \&zip_longest;
 
 sub mesh_longest {
+  my $max = max(map $#$_, @_);
   map {
     my $idx = $_;
     map $_->[$idx], @_;
-  } ( 0 .. max(map $#$_, @_) || -1 )
+  } ( 0 .. ( defined $max && $max >= 0 ? $max : -1 ) )
 }
 
 sub mesh_shortest {
+  my $min = min(map $#$_, @_);
   map {
     my $idx = $_;
     map $_->[$idx], @_;
-  } ( 0 .. min(map $#$_, @_) || -1 )
+  } ( 0 .. ( defined $min && $min >= 0 ? $min : -1 ) )
 }
 
 *mesh = \&mesh_longest;

--- a/t/mesh.t
+++ b/t/mesh.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 use List::Util::PP qw(mesh mesh_longest mesh_shortest);
 
 is_deeply( [mesh ()], [],
@@ -9,6 +9,12 @@ is_deeply( [mesh ()], [],
 
 is_deeply( [mesh ['a'..'c']], [ 'a', 'b', 'c' ],
   'mesh of one list returns the list' );
+
+is_deeply( [mesh ['one'], [1]], [ 'one' => 1 ],
+  'mesh of two single-element lists returns a one-element list of pairs' );
+
+is_deeply( [mesh_shortest ['one'], [1]], [ 'one' => 1 ],
+  'mesh_shortest of two single-element lists returns a one-element list of pairs' );
 
 is_deeply( [mesh ['one', 'two'], [1, 2]], [ one => 1, two => 2 ],
   'mesh of two lists returns a list of two pairs' );

--- a/t/zip.t
+++ b/t/zip.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 7;
+use Test::More tests => 9;
 use List::Util::PP qw(zip zip_longest zip_shortest);
 
 is_deeply( [zip ()], [],
@@ -9,6 +9,12 @@ is_deeply( [zip ()], [],
 
 is_deeply( [zip ['a'..'c']], [ ['a'], ['b'], ['c'] ],
   'zip of one list returns a list of singleton lists' );
+
+is_deeply( [zip ['one'], [1]], [ [one => 1] ],
+  'zip of two single-element lists returns a single-element list of pairs' );
+
+is_deeply( [zip_shortest ['one'], [1]], [ [one => 1] ],
+  'zip_shortest of two single-element lists returns a single-element list of pairs' );
 
 is_deeply( [zip ['one', 'two'], [1, 2]], [ [one => 1], [two => 2] ],
   'zip of two lists returns a list of pair lists' );


### PR DESCRIPTION
`mesh` and `zip` incorrectly return `undef` if all of the input arrays contain a single element, and `mesh_shortest` and `zip_shortest` incorrectly return `undef` if any of the input arrays contain a single element: the calls to `min`/`max` in the outer loops return `0` (which evaluates to false), causing `min(...) || -1` and `max(...) || -1` to evaluate to `-1`, resulting in the outer loop bodies never being executed.

In these functions, account for `min`/`max` returning `0` (i.e. when at least one/all of the input arrays contain a single element respectively).